### PR TITLE
Implement Srm::Hash#has_truthy_member?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in srm.gemspec
 gemspec
+
+gem 'pry'

--- a/lib/srm.rb
+++ b/lib/srm.rb
@@ -2,7 +2,7 @@ require "srm/version"
 
 module Srm
   def is_a_hash?(object)
-    object.is_a? Hash
+    object.is_a? ::Hash
   end
 
   extend self

--- a/lib/srm/hash.rb
+++ b/lib/srm/hash.rb
@@ -1,0 +1,9 @@
+module Srm
+  module Hash
+    def has_truthy_member?(hash, key)
+      hash[key] ? true : false
+    end
+
+    extend self
+  end
+end

--- a/lib/srm/version.rb
+++ b/lib/srm/version.rb
@@ -1,3 +1,5 @@
+require 'srm/hash'
+
 module Srm
   VERSION = "0.1.0"
 end

--- a/spec/srm/hash_spec.rb
+++ b/spec/srm/hash_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Srm::Hash do
+  subject { described_class }
+
+  context '#has_truthy_member?' do
+    it 'return true' do
+      hash = { a: true }
+      expect(subject.has_truthy_member?(hash, :a)).to eq(true)
+    end
+
+    it 'return false' do
+      hash = {}
+      expect(subject.has_truthy_member?(hash, :a)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
### Ran this benchmark to pick the fastest approach.

```
require 'benchmark/ips'

hash = {};

Benchmark.ips do |x|
  x.report(:key_and_bang_bang) do
    !!hash[:foo]
  end

  x.report(:key_and_boolean) do
    hash[:foo] ? true : false
  end

  x.compare!
end
```
### Benchmark results

```
Calculating -------------------------------------
   key_and_bang_bang   153.324k i/100ms
     key_and_boolean   158.644k i/100ms
-------------------------------------------------
   key_and_bang_bang      8.916M (± 7.5%) i/s -     44.311M
     key_and_boolean      9.716M (± 6.9%) i/s -     48.386M

Comparison:
     key_and_boolean:  9716267.4 i/s
   key_and_bang_bang:  8915818.8 i/s - 1.09x slower
```
